### PR TITLE
Allowing empty nodes for Company, GivenName, SurName and Telephone elements of ContactPerson in Metadata

### DIFF
--- a/SAML2/Metadata/Metadata.hs
+++ b/SAML2/Metadata/Metadata.hs
@@ -332,9 +332,9 @@ instance XP.XmlPickler Contact where
     XP.>$<  (XP.xpAttr "contactType" XP.xpickle
       XP.>*< XP.xpAnyAttrs
       XP.>*< XP.xpickle
-      XP.>*< XP.xpOption (xpElem "Company" XS.xpString)
-      XP.>*< XP.xpOption (xpElem "GivenName" XS.xpString)
-      XP.>*< XP.xpOption (xpElem "SurName" XS.xpString)
+      XP.>*< XP.xpOption (xpElem "Company" XP.xpText0)
+      XP.>*< XP.xpOption (xpElem "GivenName" XP.xpText0)
+      XP.>*< XP.xpOption (xpElem "SurName" XP.xpText0)
       XP.>*< XP.xpList (xpElem "EmailAddress" XS.xpAnyURI)
       XP.>*< XP.xpList (xpElem "TelephoneNumber" XP.xpText0))
 

--- a/SAML2/Metadata/Metadata.hs
+++ b/SAML2/Metadata/Metadata.hs
@@ -336,7 +336,7 @@ instance XP.XmlPickler Contact where
       XP.>*< XP.xpOption (xpElem "GivenName" XS.xpString)
       XP.>*< XP.xpOption (xpElem "SurName" XS.xpString)
       XP.>*< XP.xpList (xpElem "EmailAddress" XS.xpAnyURI)
-      XP.>*< XP.xpList (xpElem "TelephoneNumber" XS.xpString))
+      XP.>*< XP.xpList (xpElem "TelephoneNumber" XP.xpText0))
 
 data ContactType
   = ContactTypeTechnical


### PR DESCRIPTION
The problem is with certain SAML IDP's that expose metadata with `ContactPerson` element containing empty nodes (instead of not including them). According to the spec those fields are not mandatory (and thats pretty much it about them) and this can be understood in a different way. 